### PR TITLE
Pluging Setting Bug Fix

### DIFF
--- a/sms-conversations/js/index.js
+++ b/sms-conversations/js/index.js
@@ -120,7 +120,7 @@ $(document).ready(function(){
 			select = $('#smss'),
 			firstRun = true,
 			downloadSettings = function() {
-				$.getJSON( OpenVBX.home + "/plugins/sms-conversation/plugin.json", function( json ) {
+				$.post( "sms-conversation",{action:'plugin-json'}, function( json ) {
 					enableSoundNotification = json.enable_sound_notification;
 					$('#sound-notification').find('i').addClass((enableSoundNotification?'fa-bell-o':'fa-bell-slash-o'));
 				});

--- a/sms-conversations/sms-conversation.php
+++ b/sms-conversations/sms-conversation.php
@@ -37,6 +37,10 @@
 
 		exit;
 	}
+	else if($_SERVER['REQUEST_METHOD'] === 'POST' && $_POST['action'] === 'plugin-json') {
+		echo file_get_contents('plugin.json', true);
+		exit;
+	}
 
 ?>
 


### PR DESCRIPTION
- History: In version 1.1 we implemented pulling the plugin.json file in order to correctly set the default sound notification setting.
- BUG:  For some users OpenVBX.home was including 'index.php' in the URL and the plugin.json file was returning a 404 error.

-FIX: Instead of pulling the file directly from the server I'm now indirectly getting it from the plugins "rest api".  This seems to be the safter and more consistent option.

Resolves Issue #25
